### PR TITLE
`refactor:` make code more readable

### DIFF
--- a/src/Arrangers/MethodArranger.php
+++ b/src/Arrangers/MethodArranger.php
@@ -26,38 +26,41 @@ final class MethodArranger extends Arranger implements ArrangerInterface
 
     public function arrange(): string
     {
-        return $this->methods->map(function (\ReflectionMethod $method, int $key): string {
-            $parameters = Collection::make($method->getParameters());
-
+        return $this->methods->map(function (\ReflectionMethod $method): string {
             $arrangedMethod = '';
 
-            $arrangedMethod = PHP_TAB . 'public ';
-
-            if ($method->isStatic()) {
-                $arrangedMethod .= 'static ';
-            }
-
-            $arrangedMethod .= "function {$method->getName()}(";
-
-            if ($parameters->isNotEmpty()) {
-                $arrangedMethod .= ParameterArranger::from($parameters)->arrange();
-            }
-
-            $arrangedMethod .= ')';
-
-            if ($method->hasReturnType()) {
-                $arrangedMethod .= ": ";
-
-                $returnType = $method->getReturnType();
-
-                $this->processType($arrangedMethod, $returnType);
-            }
-
-            $arrangedMethod .= PHP_EOL . PHP_TAB . '{';
-            $arrangedMethod .= PHP_EOL . PHP_TAB . PHP_TAB . sprintf("throw new \\Exception('%s');", 'Implement me...');
-            $arrangedMethod .= PHP_EOL . PHP_TAB . '}';
+            $this->processMethod($arrangedMethod, $method);
 
             return $arrangedMethod;
         })->join(PHP_EOL . PHP_EOL);
+    }
+
+    protected function processMethod(string &$arrangedMethod, \ReflectionMethod $method): void
+    {
+        $arrangedMethod = PHP_TAB . 'public ';
+
+        if ($method->isStatic()) {
+            $arrangedMethod .= 'static ';
+        }
+
+        $arrangedMethod .= "function {$method->getName()}(";
+
+        $parameters = Collection::make($method->getParameters());
+
+        if ($parameters->isNotEmpty()) {
+            $arrangedMethod .= ParameterArranger::from($parameters)->arrange();
+        }
+
+        $arrangedMethod .= ')';
+
+        if ($method->hasReturnType()) {
+            $arrangedMethod .= ": ";
+
+            $this->processType($arrangedMethod, $method->getReturnType());
+        }
+
+        $arrangedMethod .= PHP_EOL . PHP_TAB . '{';
+        $arrangedMethod .= PHP_EOL . PHP_TAB . PHP_TAB . sprintf("throw new \\Exception('%s');", 'Implement me...');
+        $arrangedMethod .= PHP_EOL . PHP_TAB . '}';
     }
 }

--- a/src/Arrangers/ParameterArranger.php
+++ b/src/Arrangers/ParameterArranger.php
@@ -29,67 +29,72 @@ final class ParameterArranger extends Arranger implements ArrangerInterface
         return $this->parameters->map(function (\ReflectionParameter $parameter): string {
             $arrangedParameter = '';
 
-            $type = $parameter->getType();
-
-            if ($parameter->hasType()) {
-                $this->processType($arrangedParameter, $type);
-
-                $arrangedParameter .= ' ';
-            }
-
-            if (!$parameter->canBePassedByValue()) {
-                $arrangedParameter .= '&';
-            }
-
-            $arrangedParameter .= "\${$parameter->getName()}";
-
-            if ($parameter->isDefaultValueAvailable()) {
-                $arrangedParameter .= ' = ';
-
-                $this->processDefaultValue($arrangedParameter, $parameter);
-            }
+            $this->processParameter($arrangedParameter, $parameter);
 
             return $arrangedParameter;
         })->join(', ');
+    }
+
+    protected function processParameter(string &$arrangedParameter, \ReflectionParameter $parameter): void
+    {
+        if ($parameter->hasType()) {
+            $this->processType($arrangedParameter, $parameter->getType());
+
+            $arrangedParameter .= ' ';
+        }
+
+        if (!$parameter->canBePassedByValue()) {
+            $arrangedParameter .= self::AMPERSAND;
+        }
+
+        $arrangedParameter .= "\${$parameter->getName()}";
+
+        if ($parameter->isDefaultValueAvailable()) {
+            $arrangedParameter .= ' = ';
+
+            $this->processDefaultValue($arrangedParameter, $parameter);
+        }
     }
 
     protected function processDefaultValue(string &$arrangedParameter, \ReflectionParameter $parameter): void
     {
         if ($parameter->isDefaultValueConstant()) {
             $arrangedParameter .= "\\{$parameter->getDefaultValueConstantName()}";
-        } else {
-            $defaultValue = $parameter->getDefaultValue();
 
-            switch (true) {
-                case is_null($defaultValue):
-                    $arrangedParameter .= 'null';
+            return;
+        }
 
-                    break;
+        $defaultValue = $parameter->getDefaultValue();
 
-                case is_string($defaultValue):
-                    $arrangedParameter .= "'{$defaultValue}'";
+        switch (true) {
+            case is_null($defaultValue):
+                $arrangedParameter .= 'null';
 
-                    break;
+                break;
 
-                case is_int($defaultValue):
-                case is_float($defaultValue):
-                    $arrangedParameter .= (string) $defaultValue;
+            case is_string($defaultValue):
+                $arrangedParameter .= "'{$defaultValue}'";
 
-                    break;
+                break;
 
-                case is_bool($defaultValue):
-                    $arrangedParameter .= $defaultValue ? 'true' : 'false';
+            case is_int($defaultValue):
+            case is_float($defaultValue):
+                $arrangedParameter .= (string) $defaultValue;
 
-                    break;
+                break;
 
-                case is_array($defaultValue):
-                    $arrangedParameter .= "[]";
+            case is_bool($defaultValue):
+                $arrangedParameter .= $defaultValue ? 'true' : 'false';
 
-                    break;
+                break;
 
-                default:
-                    $arrangedParameter .= 'null';
-            }
+            case is_array($defaultValue):
+                $arrangedParameter .= "[]";
+
+                break;
+
+            default:
+                $arrangedParameter .= 'null';
         }
     }
 }


### PR DESCRIPTION
- Remove unnecessary parameter
- Remove unnecessary switch statement
- Remove unnecessary else statement with early return
- Remove unnecessary variables
- Use class constants
- Extract logic to separate method